### PR TITLE
Update dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
 export class KeyValueStore {
 


### PR DESCRIPTION
AsyncStorage from 'react-native' is deprecated and moved to '@react-native-community'